### PR TITLE
Add generic collection support. Fixes #2

### DIFF
--- a/src/Property.php
+++ b/src/Property.php
@@ -107,7 +107,7 @@ class Property extends ReflectionProperty
     {
         if (is_array($value)) {
             foreach ($value as $class) {
-                if (!$this->assertTypeEquals($type, $class)) {
+                if (! $this->assertTypeEquals($type, $class)) {
                     return false;
                 }
             }

--- a/src/Property.php
+++ b/src/Property.php
@@ -67,7 +67,7 @@ class Property extends ReflectionProperty
             return;
         }
 
-        preg_match('/\@var ([\w|\\\\]+)/', $docComment, $matches);
+        preg_match('/\@var ([\w|\\\\\[\]]+)/', $docComment, $matches);
 
         if (! count($matches)) {
             return;

--- a/src/Property.php
+++ b/src/Property.php
@@ -105,14 +105,8 @@ class Property extends ReflectionProperty
 
     protected function assertTypeEquals(string $type, $value): bool
     {
-        if (is_array($value)) {
-            foreach ($value as $class) {
-                if (! $this->assertTypeEquals($type, $class)) {
-                    return false;
-                }
-            }
-
-            return true;
+        if (strpos($type, '[]') !== false) {
+            return $this->isValidGenericCollection($type, $value);
         }
 
         if ($type === 'mixed' && $value !== null) {
@@ -124,5 +118,22 @@ class Property extends ReflectionProperty
         }
 
         return gettype($value) === (self::$typeMapping[$type] ?? $type);
+    }
+
+    protected function isValidGenericCollection(string $type, $collection): bool
+    {
+        if (! is_array($collection)) {
+            return false;
+        }
+
+        $valueType = str_replace('[]', '', $type);
+
+        foreach ($collection as $value) {
+            if (! $this->assertTypeEquals($valueType, $value)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/src/Property.php
+++ b/src/Property.php
@@ -67,7 +67,7 @@ class Property extends ReflectionProperty
             return;
         }
 
-        preg_match('/\@var ([\w|\\\\\[\]]+)/', $docComment, $matches);
+        preg_match('/\@var ((?:(?:[\w|\\\\])+(?:\[\])?)+)/', $docComment, $matches);
 
         if (! count($matches)) {
             return;

--- a/src/Property.php
+++ b/src/Property.php
@@ -105,6 +105,16 @@ class Property extends ReflectionProperty
 
     protected function assertTypeEquals(string $type, $value): bool
     {
+        if (is_array($value)) {
+            foreach ($value as $class) {
+                if (!$this->assertTypeEquals($type, $class)) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
         if ($type === 'mixed' && $value !== null) {
             return true;
         }

--- a/src/ValueObjectError.php
+++ b/src/ValueObjectError.php
@@ -23,6 +23,10 @@ class ValueObjectError extends TypeError
             $value = get_class($value);
         }
 
+        if (is_array($value)) {
+            $value = 'array';
+        }
+
         $expectedTypes = implode(', ', $property->getTypes());
 
         return new self("Invalid type: expected {$property->getFqn()} to be of type {$expectedTypes}, instead got value `{$value}`.");

--- a/src/ValueObjectException.php
+++ b/src/ValueObjectException.php
@@ -25,6 +25,10 @@ class ValueObjectException extends Exception
             $value = get_class($value);
         }
 
+        if (is_array($value)) {
+            $value = 'array';
+        }
+
         return new self("Invalid type: expected {$className}::{$propertyName} to be of type {$expectedType}; instead got value `{$value}`.");
     }
 

--- a/tests/TestClasses/OtherClass.php
+++ b/tests/TestClasses/OtherClass.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Spatie\ValueObject\Tests\TestClasses;
+
+class OtherClass
+{
+}

--- a/tests/ValueObjectTest.php
+++ b/tests/ValueObjectTest.php
@@ -5,6 +5,7 @@ namespace Spatie\ValueObject\Tests;
 use Spatie\ValueObject\ValueObject;
 use Spatie\ValueObject\ValueObjectException;
 use Spatie\ValueObject\Tests\TestClasses\DummyClass;
+use Spatie\ValueObject\Tests\TestClasses\OtherClass;
 
 class ValueObjectTest extends TestCase
 {
@@ -121,6 +122,45 @@ class ValueObjectTest extends TestCase
         new class(['foo' => new class() {
         }]) extends ValueObject {
             /** @var \Spatie\ValueObject\Tests\TestClasses\DummyClass */
+            public $foo;
+        };
+    }
+    
+    /** @test */
+    public function generic_collections_are_supported()
+    {
+        new class(['foo' => [
+            new DummyClass(),
+            new DummyClass(),
+            new DummyClass(),
+        ]]) extends ValueObject {
+            /** @var \Spatie\ValueObject\Tests\TestClasses\DummyClass[] */
+            public $foo;
+        };
+
+        $this->markTestSucceeded();
+
+        $this->expectException(ValueObjectException::class);
+
+        new class(['foo' => [
+            new DummyClass(),
+            new DummyClass(),
+            new OtherClass(),
+        ]]) extends ValueObject {
+            /** @var \Spatie\ValueObject\Tests\TestClasses\DummyClass[] */
+            public $foo;
+        };
+    }
+
+    /** @test */
+    public function an_exception_is_thrown_for_a_generic_collection_of_null()
+    {
+        $this->expectException(ValueObjectException::class);
+
+        new class(['foo' => [
+            null,
+        ]]) extends ValueObject {
+            /** @var null[] */
             public $foo;
         };
     }

--- a/tests/ValueObjectTest.php
+++ b/tests/ValueObjectTest.php
@@ -125,15 +125,11 @@ class ValueObjectTest extends TestCase
             public $foo;
         };
     }
-    
+
     /** @test */
     public function generic_collections_are_supported()
     {
-        new class(['foo' => [
-            new DummyClass(),
-            new DummyClass(),
-            new DummyClass(),
-        ]]) extends ValueObject {
+        new class(['foo' => [new DummyClass(), new DummyClass(), new DummyClass()]]) extends ValueObject {
             /** @var \Spatie\ValueObject\Tests\TestClasses\DummyClass[] */
             public $foo;
         };
@@ -142,11 +138,7 @@ class ValueObjectTest extends TestCase
 
         $this->expectException(ValueObjectException::class);
 
-        new class(['foo' => [
-            new DummyClass(),
-            new DummyClass(),
-            new OtherClass(),
-        ]]) extends ValueObject {
+        new class(['foo' => [new DummyClass(), new DummyClass(), new OtherClass()]]) extends ValueObject {
             /** @var \Spatie\ValueObject\Tests\TestClasses\DummyClass[] */
             public $foo;
         };
@@ -157,9 +149,7 @@ class ValueObjectTest extends TestCase
     {
         $this->expectException(ValueObjectException::class);
 
-        new class(['foo' => [
-            null,
-        ]]) extends ValueObject {
+        new class(['foo' => [null]]) extends ValueObject {
             /** @var null[] */
             public $foo;
         };

--- a/tests/ValueObjectTest.php
+++ b/tests/ValueObjectTest.php
@@ -129,7 +129,7 @@ class ValueObjectTest extends TestCase
     /** @test */
     public function generic_collections_are_supported()
     {
-        new class(['foo' => [new DummyClass(), new DummyClass(), new DummyClass()]]) extends ValueObject {
+        new class(['foo' => [new DummyClass()]]) extends ValueObject {
             /** @var \Spatie\ValueObject\Tests\TestClasses\DummyClass[] */
             public $foo;
         };
@@ -138,7 +138,7 @@ class ValueObjectTest extends TestCase
 
         $this->expectException(ValueObjectException::class);
 
-        new class(['foo' => [new DummyClass(), new DummyClass(), new OtherClass()]]) extends ValueObject {
+        new class(['foo' => [new OtherClass()]]) extends ValueObject {
             /** @var \Spatie\ValueObject\Tests\TestClasses\DummyClass[] */
             public $foo;
         };
@@ -150,7 +150,7 @@ class ValueObjectTest extends TestCase
         $this->expectException(ValueObjectException::class);
 
         new class(['foo' => [null]]) extends ValueObject {
-            /** @var null[] */
+            /** @var string[] */
             public $foo;
         };
     }

--- a/tests/ValueObjectTest.php
+++ b/tests/ValueObjectTest.php
@@ -162,7 +162,7 @@ class ValueObjectTest extends TestCase
 
         $this->markTestSucceeded();
 
-        $this->expectException(ValueObjectException::class);
+        $this->expectException(ValueObjectError::class);
 
         new class(['foo' => [new OtherClass()]]) extends ValueObject {
             /** @var \Spatie\ValueObject\Tests\TestClasses\DummyClass[] */
@@ -173,7 +173,7 @@ class ValueObjectTest extends TestCase
     /** @test */
     public function an_exception_is_thrown_for_a_generic_collection_of_null()
     {
-        $this->expectException(ValueObjectException::class);
+        $this->expectException(ValueObjectError::class);
 
         new class(['foo' => [null]]) extends ValueObject {
             /** @var string[] */


### PR DESCRIPTION
Although you tagged it with 'good first issue', I'll admit it wasn't easy :p There is probably a better way to solve this, but I'll submit the PR anyway, maybe get some good feedback. If I'm wasting your time; sorry, but just close it, no hard feelings.

Some issues I ran into: 

1. `ValueObjectException` should get a value of the class in the collection, not the array the class is in. But that would require changes for `set` in `Property`. I added an `is_array` check to `ValueObjectException` to avoid `array to string` issues , but there should be a better way to handle this.
2. `assertTypeEquals` in `Property` will recursively walk through the values of the array to check if the type matches. I feel like this should maybe be done in `isValidType`, but how combine this with the support for multiple types?
3. Looking at `resolveTypeDefinition` I'm not sure how to handle support for multiple types. Besides that, would probably add a `isGenericCollection` property to solve issues we now have in point 1 and 2.

I would love some feedback in order to improve the PR and maybe you can specify handling multiple types with generics. Not sure if there are any use cases for it. For example FooClass or a collection of FooClass.