### PR TITLE
Throw exception on uninitialized non-nullable property.

### DIFF
--- a/src/Property.php
+++ b/src/Property.php
@@ -19,7 +19,7 @@ class Property extends ReflectionProperty
     protected $hasTypeDeclaration = false;
 
     /** @var bool */
-    protected $isNullable = true;
+    protected $isNullable = false;
 
     /** @var bool */
     protected $isInitialised = false;
@@ -72,12 +72,16 @@ class Property extends ReflectionProperty
         $docComment = $this->getDocComment();
 
         if (! $docComment) {
+            $this->isNullable = true;
+
             return;
         }
 
         preg_match('/\@var ((?:(?:[\w|\\\\])+(?:\[\])?)+)/', $docComment, $matches);
 
         if (! count($matches)) {
+            $this->isNullable = true;
+
             return;
         }
 

--- a/src/Property.php
+++ b/src/Property.php
@@ -19,7 +19,7 @@ class Property extends ReflectionProperty
     protected $hasTypeDeclaration = false;
 
     /** @var bool */
-    protected $isNullable = false;
+    protected $isNullable = true;
 
     /** @var bool */
     protected $isInitialised = false;
@@ -60,6 +60,11 @@ class Property extends ReflectionProperty
     public function getFqn(): string
     {
         return "{$this->getDeclaringClass()->getName()}::{$this->getName()}";
+    }
+
+    public function isNullable(): bool
+    {
+        return $this->isNullable;
     }
 
     protected function resolveTypeDefinition()

--- a/src/ValueObject.php
+++ b/src/ValueObject.php
@@ -23,6 +23,13 @@ abstract class ValueObject
         $properties = $this->getPublicProperties($class);
 
         foreach ($properties as $property) {
+            if (
+                ! isset($parameters[$property->getName()])
+                && ! $property->isNullable()
+            ) {
+                throw ValueObjectError::uninitialized($property);
+            }
+
             $value = $parameters[$property->getName()] ?? null;
 
             $property->set($value);

--- a/src/ValueObjectError.php
+++ b/src/ValueObjectError.php
@@ -32,7 +32,7 @@ class ValueObjectError extends TypeError
         return new self("Invalid type: expected {$property->getFqn()} to be of type {$expectedTypes}, instead got value `{$value}`.");
     }
 
-    public static function uninitializedProperty(Property $property): ValueObjectError
+    public static function uninitialized(Property $property): ValueObjectError
     {
         return new self("Non-nullable property {$property->getFqn()} has not been initialized.");
     }

--- a/tests/ValueObjectTest.php
+++ b/tests/ValueObjectTest.php
@@ -55,6 +55,17 @@ class ValueObjectTest extends TestCase
     }
 
     /** @test */
+    public function null_is_allowed_only_if_explicitly_specified()
+    {
+        $this->expectException(ValueObjectError::class);
+
+        new class(['foo' => null]) extends ValueObject {
+            /** @var string */
+            public $foo;
+        };
+    }
+
+    /** @test */
     public function unknown_properties_throw_an_error()
     {
         $this->expectException(ValueObjectError::class);

--- a/tests/ValueObjectTest.php
+++ b/tests/ValueObjectTest.php
@@ -214,6 +214,11 @@ class ValueObjectTest extends TestCase
             public $foo;
         };
 
+        new class(['foo' => null]) extends ValueObject {
+            /** This is a variable without type declaration */
+            public $foo;
+        };
+
         new class(['foo' => 1]) extends ValueObject {
             public $foo;
         };


### PR DESCRIPTION
Resolves #8.

Changed default value for `Property::$isNullable` to `true` to be consistent with test `empty_type_declaration_allows_everything`.

Added test to allow only explicitly specified nullable property.